### PR TITLE
docs: Fix a few typos

### DIFF
--- a/chapter_2/module_2_4.py
+++ b/chapter_2/module_2_4.py
@@ -16,7 +16,7 @@ MAX_VAL = sys.maxsize
 
 class MaxPQ(object):
 
-    """Max piority queue implementation.
+    """Max priority queue implementation.
     """
 
     def __init__(self, size: int) -> None:
@@ -83,8 +83,8 @@ class MaxPQ(object):
             pos = index
 
     def insert(self, val: CT) -> None:
-        """Insert element into piority queue, append `val` to priority queue,
-        then call `swim` method to restore piority queue's order.
+        """Insert element into priority queue, append `val` to priority queue,
+        then call `swim` method to restore priority queue's order.
 
         Args:
             val (CT): element to insert
@@ -113,7 +113,7 @@ class MaxPQ(object):
 
     # 2.4.27 practice
     def min_val(self) -> CT:
-        """Return minimum value in piority queue.
+        """Return minimum value in priority queue.
 
         Returns:
             CT: maximum value in priority queue
@@ -192,7 +192,7 @@ class MaxPQ(object):
         self.swim_effective(self._size)
 
     def max_val(self) -> CT:
-        """Return maximum value in piority queue.
+        """Return maximum value in priority queue.
 
         Returns:
             CT: maximum value in priority queue
@@ -281,8 +281,8 @@ class MinPQ(object):
             pos = index
 
     def insert(self, val: CT) -> None:
-        """Insert element into piority queue, append `val` to priority queue,
-        then call `swim` method to restore piority queue's order.
+        """Insert element into priority queue, append `val` to priority queue,
+        then call `swim` method to restore priority queue's order.
 
         Args:
             val (CT): element to insert
@@ -336,7 +336,7 @@ class MinPQ(object):
         return min_val
 
     def min_val(self) -> CT:
-        """Return minimum value in piority queue.
+        """Return minimum value in priority queue.
 
         Returns:
             CT: minimum value in priority queue
@@ -493,8 +493,8 @@ class MaxPQDynamic(object):
             pos = index
 
     def insert(self, val: CT) -> None:
-        """Insert element into piority queue, append `val` to priority queue,
-        then call `swim` method to restore piority queue's order.
+        """Insert element into priority queue, append `val` to priority queue,
+        then call `swim` method to restore priority queue's order.
 
         Args:
             val (CT): element to insert
@@ -547,7 +547,7 @@ class MaxPQDynamic(object):
         return max_val
 
     def max_val(self) -> CT:
-        """Return maximum value in piority queue.
+        """Return maximum value in priority queue.
 
         Returns:
             CT: maximum value in priority queue
@@ -638,8 +638,8 @@ class MinPQDynamic(object):
             pos = index
 
     def insert(self, val: CT) -> None:
-        """Insert element into piority queue, append `val` to priority queue,
-        then call `swim` method to restore piority queue's order.
+        """Insert element into priority queue, append `val` to priority queue,
+        then call `swim` method to restore priority queue's order.
 
         Args:
             val (CT): element to insert
@@ -692,7 +692,7 @@ class MinPQDynamic(object):
         return min_val
 
     def min_val(self) -> CT:
-        """Return minimum value in piority queue.
+        """Return minimum value in priority queue.
 
         Returns:
             CT: minimum value in priority queue

--- a/chapter_4/module_4_3.py
+++ b/chapter_4/module_4_3.py
@@ -370,7 +370,7 @@ class PrimMST(object):
 class KruskalMST(object):
 
     """
-      Kruskal-Minimum-Spanning-Tree algorithm. This is a greedy stategy algorithm. First
+      Kruskal-Minimum-Spanning-Tree algorithm. This is a greedy strategy algorithm. First
     put all edges into the priority queue, then delete the minimum-weight edge in the
     priority queue. Check if those vertices on the both side of the edge is connected.
     If connected, ignore the edge, if not, then use a disjoint set to connect two vertices

--- a/chapter_4/module_4_4.py
+++ b/chapter_4/module_4_4.py
@@ -418,7 +418,7 @@ class BellmanFordSP(ShortestPath):
     it's a queue-based version. First enqueue the source vertex, and dequeue the vertex,
     'relax' all adjacent edges and put the adjacent vertices into the queue until the queue
     is empty or find the negative cycle. A negative cycle check is nessesary every V times
-    relaxtion.The cost of running time is proportional to O(V + E), the worst case is VE.
+    relaxation.The cost of running time is proportional to O(V + E), the worst case is VE.
     This is a universal algorithm for Shortest Path algorithm.
     >>> test_data = ((4, 5, 0.35), (5, 4, 0.35), (4, 7, 0.37), (5, 7, 0.28), (7, 5, 0.28),
     ...              (5, 1, 0.32), (0, 4, 0.38), (0, 2, 0.26), (7, 3, 0.39), (1, 3, 0.29),

--- a/chapter_5/module_5_1.py
+++ b/chapter_5/module_5_1.py
@@ -56,7 +56,7 @@ class MSD(object):
     recursion depth exceeded, MSD switch to insertion sort when handling small arrays.
     The performance will be not fine when most of input strings are the same. And the cost
     of space is very expensive because each recursion sort need to create a counting array,
-    and some of recursions is unnessesary.
+    and some of recursions is unnecessary.
     >>> test_data = ['she', 'sells', 'seashells', 'by', 'the', 'sea', 'shore',
     ...              'the', 'shells', 'she', 'sells', 'are', 'surely', 'seashells']
     >>> msd = MSD()
@@ -118,7 +118,7 @@ class Quick3String(object):
     """
       Quick Three Way algorithm for string sorting purpose. This is almost the
     same as Quick Three Way, but it takes ith character of each string as comparison.
-    It's really helpful when large repetive strings as input strings.
+    It's really helpful when large repetitive strings as input strings.
     >>> test_data = ['she', 'sells', 'seashells', 'by', 'the', 'sea', 'shore',
     ...              'the', 'shells', 'she', 'sells', 'are', 'surely', 'seashells']
     >>> q3s = Quick3String()


### PR DESCRIPTION
There are small typos in:
- chapter_2/module_2_4.py
- chapter_4/module_4_3.py
- chapter_4/module_4_4.py
- chapter_5/module_5_1.py

Fixes:
- Should read `priority` rather than `piority`.
- Should read `unnecessary` rather than `unnessesary`.
- Should read `strategy` rather than `stategy`.
- Should read `repetitive` rather than `repetive`.
- Should read `relaxation` rather than `relaxtion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md